### PR TITLE
Support rescue catch after

### DIFF
--- a/lib/reather.ex
+++ b/lib/reather.ex
@@ -88,10 +88,7 @@ defmodule Reather do
   end
 
   @doc """
-  Inspect the reather.
-
-  **Warning**: It _runs_ the reather. So, the provided
-  reather should not have side effects.
+  Inspect the reather result when run.
   """
   def inspect(%Reather{} = r, opts \\ []) do
     Reather.new(fn env ->

--- a/lib/reather/macros.ex
+++ b/lib/reather/macros.ex
@@ -27,7 +27,6 @@ defmodule Reather.Macros do
   def build_body(body) do
     # Elixir function body is implicit try.
     # So we need to wrap the body with try to support do, else, rescue, catch and after.
-
     {[do: do_block], rest} = body |> Keyword.split([:do])
     built_do_block = build_do_block(do_block)
 
@@ -108,14 +107,6 @@ defmodule Reather.Macros do
                   end
                 end
                 |> Reather.new()
-              end).()
-        end
-
-      {:=, _ctx, [lhs, rhs]}, acc ->
-        quote do
-          unquote(rhs)
-          |> (fn unquote(lhs) ->
-                unquote(acc)
               end).()
         end
 

--- a/lib/reather/macros.ex
+++ b/lib/reather/macros.ex
@@ -71,17 +71,6 @@ defmodule Reather.Macros do
     parse_exprs([expr])
   end
 
-  defp build_match(lhs, acc) do
-    quote do
-      {:ok, unquote(lhs)} ->
-        unquote(acc)
-        |> Reather.run(env)
-
-      {:error, _} = error ->
-        error
-    end
-  end
-
   defp parse_exprs(exprs) do
     [ret | body] = exprs |> Enum.reverse()
 
@@ -93,8 +82,6 @@ defmodule Reather.Macros do
     body
     |> List.foldl(wrapped_ret, fn
       {:<-, _ctx, [lhs, rhs]}, acc ->
-        match = build_match(lhs, acc)
-
         quote do
           unquote(rhs)
           |> Reather.wrap()
@@ -103,7 +90,12 @@ defmodule Reather.Macros do
                   r
                   |> Reather.run(env)
                   |> case do
-                    unquote(match)
+                    {:ok, unquote(lhs)} ->
+                      unquote(acc)
+                      |> Reather.run(env)
+
+                    {:error, _} = error ->
+                      error
                   end
                 end
                 |> Reather.new()

--- a/test/reather/else_test.exs
+++ b/test/reather/else_test.exs
@@ -12,6 +12,7 @@ defmodule ReatherTest.ElseTest do
       x + y
     else
       {:error, "zero"} -> {:ok, 2 * b}
+      other -> other
     end
 
     reather foo2(a, b) do
@@ -65,6 +66,7 @@ defmodule ReatherTest.ElseTest do
         x + y
       else
         {:error, "zero"} -> {:ok, 2 * b}
+        other -> other
       end
     end
 


### PR DESCRIPTION
1. def 는 else, rescue, catch, after 를 지원하는데, reather 는 else 만 지원해서 모두 지원하도록 함.
2. else 가 모든 `<-` 의 case 에 들어가는것보다는 def 와 마찬가지로 전체 do block 실행 후에 pattern matching 하도록 함.
3. `lhs = rhs` 가 다른 expr 과 다른 점이 없어서 삭제함.