### PR TITLE
Add Reather.chain

### DIFF
--- a/lib/reather.ex
+++ b/lib/reather.ex
@@ -119,13 +119,13 @@ defmodule Reather do
   def wrap(%Reather{} = r), do: r
   def wrap(v), do: of(v)
 
-  def chain(%Reather{} = rhs, acc) when is_function(acc, 1) do
+  def chain(%Reather{} = rhs, chain_fun) when is_function(chain_fun, 1) do
     Reather.new(fn env ->
       rhs
       |> Reather.run(env)
       |> case do
         {:ok, value} ->
-          acc.(value) |> Reather.run(env)
+          chain_fun.(value) |> Reather.run(env)
 
         {:error, _} = error ->
           error

--- a/lib/reather.ex
+++ b/lib/reather.ex
@@ -118,4 +118,18 @@ defmodule Reather do
   """
   def wrap(%Reather{} = r), do: r
   def wrap(v), do: of(v)
+
+  def chain(%Reather{} = rhs, acc) when is_function(acc, 1) do
+    Reather.new(fn env ->
+      rhs
+      |> Reather.run(env)
+      |> case do
+        {:ok, value} ->
+          acc.(value) |> Reather.run(env)
+
+        {:error, _} = error ->
+          error
+      end
+    end)
+  end
 end

--- a/lib/reather/macros.ex
+++ b/lib/reather/macros.ex
@@ -76,7 +76,7 @@ defmodule Reather.Macros do
 
     wrapped_ret =
       quote do
-        Reather.new(fn _ -> Reather.Either.new(unquote(ret)) end)
+        unquote(ret) |> Reather.wrap()
       end
 
     body

--- a/lib/reather/macros.ex
+++ b/lib/reather/macros.ex
@@ -85,21 +85,7 @@ defmodule Reather.Macros do
         quote do
           unquote(rhs)
           |> Reather.wrap()
-          |> (fn %Reather{} = r ->
-                fn env ->
-                  r
-                  |> Reather.run(env)
-                  |> case do
-                    {:ok, unquote(lhs)} ->
-                      unquote(acc)
-                      |> Reather.run(env)
-
-                    {:error, _} = error ->
-                      error
-                  end
-                end
-                |> Reather.new()
-              end).()
+          |> Reather.chain(fn unquote(lhs) -> unquote(acc) end)
         end
 
       expr, acc ->


### PR DESCRIPTION
`<-` 구현에서 Reather.chain 을 분리해냄.

1. 기존처럼 macro 에서 :ok, :error pattern matching을 할 경우, rhs 가 :ok 투플만 나올경우 dialyzer 에러가 발생하게 됨.
2. 반복되는 코드를 macro 로 하면 code bloat 우려가 있음.

