### PR TITLE
Generate case, try which fits best

### DIFF
--- a/test/reather/after_test.exs
+++ b/test/reather/after_test.exs
@@ -30,7 +30,6 @@ defmodule ReatherTest.AfterTest do
     assert {{:ok, 3}, "foo\n"} ==
              fn -> Target.foo(1, 2) |> Reather.run() end
              |> with_io()
-             |> IO.inspect()
 
     assert {{:ok, 4}, "foo\n"} ==
              fn ->

--- a/test/reather/else_test.exs
+++ b/test/reather/else_test.exs
@@ -57,7 +57,7 @@ defmodule ReatherTest.ElseTest do
     assert {:error, "same"} == Target.foo2(2, 2) |> Reather.run()
 
     assert {:ok, 2} == Target.foo3(2, 2) |> Reather.run()
-    assert_raise TryClauseError, fn -> Target.foo3(0, 2) |> Reather.run() end
+    assert_raise CaseClauseError, fn -> Target.foo3(0, 2) |> Reather.run() end
   end
 
   test "inline reather" do

--- a/test/reather/lazy_test.exs
+++ b/test/reather/lazy_test.exs
@@ -12,10 +12,10 @@ defmodule ReatherTest.LazyTest do
   end
 
   test "inspect doesn't run until call Reather.run" do
-    {%Reather{}, ""} =
-      with_io(fn ->
-        Target.single()
-      end)
+    assert {%Reather{}, ""} =
+             with_io(fn ->
+               Target.single()
+             end)
 
     assert with_io(fn ->
              Target.single() |> Reather.run(%{})


### PR DESCRIPTION
기존에는 항상 `try` 로 변환하는 탓에, compiler warning 을 없애기 위해 빈 `after` clause를 넣어서 code bloat이 발생했음.

이것을 
1. do 만 있는 경우 어떤것으로도 wrap 하지 않음. 
2. do, else 만 있는 경우 case로 wrap.
3. do + any combination of rescue, catch, after 인 경우, try 로 wrap

하도록 하여 최소한의 코드가 생성되도록 함.